### PR TITLE
Update lint action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
 name: Lint Markdown
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,4 +14,4 @@ jobs:
           node-version: '12'
 
       - run: npm install
-      - run: npm run lint-md
+      - run: npm run lint

--- a/package.json
+++ b/package.json
@@ -3,8 +3,7 @@
   "version": "1.0.0",
   "description": "DevSecOps Learning",
   "scripts": {
-    "lint-md": "remark . -f",
-    "lint-md-fix": "remark . -o"
+    "lint": "remark . -f"
   },
   "remarkConfig": {
     "plugins": [


### PR DESCRIPTION
Rename `lint-md` -> `lint` to have a common approach in all our repos
Also, only run lint on push - pull request flow will be different. We may turn this around (i.e. pull request only) depending if there will be a PR by a user outside this org