### PR TITLE
Add lint badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![Lint Markdown](https://github.com/devsecops-learning/docs/workflows/Lint%20Markdown/badge.svg)
+
 # Public team documents
 
 A first public repository


### PR DESCRIPTION
Creates a nice looking badge, reflecting status of the lint CI workflow, like this:

![image](https://user-images.githubusercontent.com/2457146/99690620-5b2a8780-2a56-11eb-88a8-d31585f6828d.png)
